### PR TITLE
Fix DB.Close to avoid NPEs and to actually close the DB

### DIFF
--- a/postgrestest_test.go
+++ b/postgrestest_test.go
@@ -34,7 +34,7 @@ func TestNew(t *testing.T) {
 	c.Assert(err, qt.Equals, nil)
 	defer sdb.Close()
 
-	row = db.QueryRow(`SELECT COUNT(nspname) FROM pg_namespace WHERE nspname = '` + schema + `'`)
+	row = sdb.QueryRow(`SELECT COUNT(nspname) FROM pg_namespace WHERE nspname = '` + schema + `'`)
 	var count int
 	c.Assert(row.Scan(&count), qt.Equals, nil)
 	c.Assert(count, qt.Equals, 0)


### PR DESCRIPTION
Fixes several behaviors involving `Close`:
- `DB.Close` was not actually closing the database, leading to connection leaks that exceeded Postgres `max_connections` in larger sets of tests.
- If the schema failed to be created in `New`, the recently-created `db` was not closing (potentially leaking connection as well).
- If someone changed `DB.DB` to nil, a panic would occur.

All calls to the database that may lock for a while are run with `runWithTimeout`.

Also added `PgTestDisable` so tests don't have to try and fail to create a new database just to check that Postgres tests should be disabled.